### PR TITLE
Back to unmodified state with undo

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -622,6 +622,27 @@ mod tests {
         assert_eq!(msg, "");
     }
 
+    #[test]
+    fn undo_modified() {
+        let input = DummyInputs(vec![
+            key('a'),
+            key('b'),
+            key('c'),
+            ctrl('m'),
+            ctrl('u'),
+            ctrl('u'),
+            ctrl('q'),
+            ctrl('q'),
+        ]);
+        let mut editor = Editor::new(input, Discard, Some((80, 24))).unwrap();
+        editor.edit().unwrap();
+
+        let lines = editor.lines().collect::<Vec<_>>();
+        assert_eq!(lines, vec![""]);
+
+        assert!(!editor.bufs[0].modified());
+    }
+
     macro_rules! test_text_edit {
     ($title:ident, $title_undo:ident, $title_redo:ident {
         before: $before:expr,

--- a/src/history.rs
+++ b/src/history.rs
@@ -20,10 +20,10 @@ impl History {
         self.ongoing.push(diff);
     }
 
-    pub fn finish_ongoing_edit(&mut self) {
+    pub fn finish_ongoing_edit(&mut self) -> bool {
         debug_assert!(self.entries.len() <= MAX_ENTRIES);
         if self.ongoing.is_empty() {
-            return; // Do nothing when no change was added
+            return false; // Do nothing when no change was added
         }
 
         let diffs = mem::replace(&mut self.ongoing, vec![]);
@@ -40,6 +40,7 @@ impl History {
 
         self.index += 1;
         self.entries.push_back(diffs);
+        true
     }
 
     fn apply_diffs<'a, I: Iterator<Item = &'a EditDiff>>(
@@ -53,23 +54,25 @@ impl History {
         })
     }
 
-    pub fn undo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize)> {
-        self.finish_ongoing_edit();
+    pub fn undo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize, bool)> {
+        let ongoing = self.finish_ongoing_edit();
         if self.index == 0 {
             return None;
         }
         self.index -= 1;
         let i = self.entries[self.index].iter().rev();
-        Some(Self::apply_diffs(i, UndoRedo::Undo, rows))
+        let (x, y, dirty_start) = Self::apply_diffs(i, UndoRedo::Undo, rows);
+        Some((x, y, dirty_start, ongoing))
     }
 
-    pub fn redo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize)> {
-        self.finish_ongoing_edit();
+    pub fn redo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize, bool)> {
+        let ongoing = self.finish_ongoing_edit();
         if self.index == self.entries.len() {
             return None;
         }
         self.index += 1;
         let i = self.entries[self.index - 1].iter();
-        Some(Self::apply_diffs(i, UndoRedo::Redo, rows))
+        let (x, y, dirty_start) = Self::apply_diffs(i, UndoRedo::Redo, rows);
+        Some((x, y, dirty_start, ongoing))
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -55,24 +55,24 @@ impl History {
     }
 
     pub fn undo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize, bool)> {
-        let ongoing = self.finish_ongoing_edit();
+        let edited = self.finish_ongoing_edit();
         if self.index == 0 {
             return None;
         }
         self.index -= 1;
         let i = self.entries[self.index].iter().rev();
         let (x, y, dirty_start) = Self::apply_diffs(i, UndoRedo::Undo, rows);
-        Some((x, y, dirty_start, ongoing))
+        Some((x, y, dirty_start, edited))
     }
 
     pub fn redo(&mut self, rows: &mut Vec<Row>) -> Option<(usize, usize, usize, bool)> {
-        let ongoing = self.finish_ongoing_edit();
+        let edited = self.finish_ongoing_edit();
         if self.index == self.entries.len() {
             return None;
         }
         self.index += 1;
         let i = self.entries[self.index - 1].iter();
         let (x, y, dirty_start) = Self::apply_diffs(i, UndoRedo::Redo, rows);
-        Some((x, y, dirty_start, ongoing))
+        Some((x, y, dirty_start, edited))
     }
 }

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -544,8 +544,8 @@ impl TextBuffer {
 
     pub fn undo(&mut self) -> bool {
         let state = self.history.undo(&mut self.row);
-        if let Some((_, _, _, ongoing)) = state {
-            if !ongoing {
+        if let Some((_, _, _, edited)) = state {
+            if !edited {
                 self.modified_count -= 1;
             }
             self.tmp_modified = false;
@@ -555,8 +555,8 @@ impl TextBuffer {
 
     pub fn redo(&mut self) -> bool {
         let state = self.history.redo(&mut self.row);
-        if let Some((_, _, _, ongoing)) = state {
-            if !ongoing {
+        if let Some((_, _, _, edited)) = state {
+            if !edited {
                 self.modified_count += 1;
             }
             self.tmp_modified = false;


### PR DESCRIPTION
Text buffer keeps modified state even if a user undo all modifications,
because undo doesn't restore unmodified state.

This change counts how many times a buffer is modified,
and restore unmodified state if changes are undone.
