### PR TITLE
Impl blocking read

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -248,6 +248,7 @@ where
         Ok(())
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn handle_quit(&mut self, s: InputSeq) -> Result<EditStep> {
         let modified = self.bufs.iter().any(|b| b.modified());
         if !modified || self.quitting {

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,10 +31,9 @@ impl StdinRawMode {
         termios.c_oflag &= !OPOST;
         // Ensure character size is 8bits
         termios.c_cflag |= CS8;
-        // Do not wait for next byte with blocking since reading 0 byte is permitted
-        termios.c_cc[VMIN] = 0;
-        // Set read timeout to 1/10 second it enables 100ms timeout on read()
-        termios.c_cc[VTIME] = 1;
+        // Implement blocking read for efficient reading of input
+        termios.c_cc[VMIN] = 1;
+        termios.c_cc[VTIME] = 0;
         // Apply terminal configurations
         tcsetattr(fd, TCSAFLUSH, &termios)?;
 
@@ -319,8 +318,8 @@ impl InputSequences {
 impl Iterator for InputSequences {
     type Item = Result<InputSeq>;
 
-    // Read next byte from stdin with timeout 100ms. If nothing was read, it returns InputSeq::Unidentified.
-    // This method never returns None so for loop never ends
+    // Read next byte from stdin, if nothing was read, it returns InputSeq::Unidentified.
+    // This method never returns None so for loop never ends.
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.read_seq())
     }


### PR DESCRIPTION
Running strace on Kiro reveals that it polls every 100ms for an input
returning 0 if nothing was read. This pull request implements a blocking
read for noncanonical mode as specified in the canonical and
noncanonical section in the termios man page:
https://man7.org/linux/man-pages/man3/termios.3.html

This provides a more efficient reading of the input, by blocking after
an empty read of 0 bytes without wasteful polling cycles.